### PR TITLE
Added logic to fix problems when using the default region to create a Bucket

### DIFF
--- a/lib/aws/s3.js
+++ b/lib/aws/s3.js
@@ -44,11 +44,13 @@ S3.prototype.createBucket = function() {
   var region      = this.region;
 
   return new RSVP.Promise(function(resolve, reject) {
-    var params = {
+    var params = (region !== 'us-east-1') ? {
       Bucket: bucket,
       CreateBucketConfiguration : {
         LocationConstraint : region
       }
+    } : {
+      Bucket: bucket
     };
 
     s3.createBucket(params, function(err, data) {

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -34,7 +34,7 @@ var DeployCommand = {
           region: config.region
         });
 
-        ui.log("Creating bucket to upload lamba function code");
+        ui.log("Creating bucket to upload lamba function code => " + util.inspect(config));
 
         return s3Bucket.createBucket();
       })


### PR DESCRIPTION
As per AWS docs. One cant use us-east-1 as a LocationConstraint when creating a Bucket.

This is a 'default bug behaviour' on their part. And the fix is a work around for that.